### PR TITLE
[READY] Change tag output for running-instances in aws aliases

### DIFF
--- a/aws/.aws/cli/alias
+++ b/aws/.aws/cli/alias
@@ -6,9 +6,9 @@ creds = configure list
 whoami = sts get-caller-identity
 
 running-instances = ec2 describe-instances \
-    --filter Name=instance-state-name,Values=running \
-    --query 'Reservations[].Instances[].{ID: InstanceId,Name: Tags[?Key==`Name`].Value | [0],Type: InstanceType, Platform: Platform || `Linux`}' \
-    --output table
+                        --filter Name=instance-state-name,Values=running \
+                        --query 'Reservations[].Instances[].{ID: InstanceId,Name: Tags[?Key==`Name`].Value | [0], IP: PublicIpAddress || PrivateIpAddress, Platform: Platform || `Linux`, Tags: join(`:`, Tags[?Key!=`aws:autoscaling:groupName`].[Key, Value] | sort_by(@, &[0])[])}' \
+                        --output table
 
 amis = ec2 describe-images \
            --query 'Images[].[ImageId, Name, CreationDate] | reverse(sort_by(@, &[2]))' \


### PR DESCRIPTION
Makes it easier to see tags on ec2 instances with my `aws running-instances` alias