### PR TITLE
[READY] Adding aws env specifics and autofmt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,9 @@
 [submodule "vim/.vim/bundle/vim-go-slide"]
 	path = vim/.vim/bundle/vim-go-slide
 	url = https://github.com/zchee/vim-go-slide
+[submodule "vim/.vim/bundle/vim-rego"]
+	path = vim/.vim/bundle/vim-rego
+	url = https://github.com/tsandall/vim-rego.git
+[submodule "vim/.vim/bundle/vim-autoformat"]
+	path = vim/.vim/bundle/vim-autoformat
+	url = https://github.com/Chiel92/vim-autoformat.git

--- a/README.md
+++ b/README.md
@@ -51,7 +51,17 @@ cd ~/dotfiles
 make CONFIG=./make/workstation-pkgs.mk unstow
 ```
 
-## Updating
+## Submodule Updating
+### Update to match this repo
+
+If submodules are bumped to a newer ref and then committed. Other repos pulling this repo down
+need to do the following in additition to `git pull --rebase upstream master`:
+
+```
+git submodule update
+```
+> This will update all refs that might still show as diffs in `master`
+
 ### vim bundles
 Individual update of a vim plugin
 ```bash

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -94,6 +94,7 @@ export LESS_TERMCAP_ue=$'\e[0m'              # reset underline
 alias ll="ls -lah"
 alias tmux="tmux -2"
 alias diff="diff -u"
+alias def="type"
 # Allows for piping vim doc
 alias pvim="(trap 'rm ~/temp$$' exit; vim -c 'setlocal spell' ~/temp$$ >/dev/tty; cat ~/temp$$)"
 

--- a/bash/.bashrc.d/10-ag
+++ b/bash/.bashrc.d/10-ag
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 # silver searcher specifics
 if command -v ag > /dev/null 2>&1; then
   # shellcheck disable=SC2016

--- a/bash/.bashrc.d/10-docker
+++ b/bash/.bashrc.d/10-docker
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 # docker specifics
 if command -v docker > /dev/null 2>&1; then
 

--- a/bash/.bashrc.d/10-golang
+++ b/bash/.bashrc.d/10-golang
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 # go specifics
 if command -v go > /dev/null 2>&1; then
   export GOPATH="${HOME}/go"

--- a/bash/.bashrc.d/10-hub
+++ b/bash/.bashrc.d/10-hub
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 # hub specifics
 if command -v hub > /dev/null 2>&1; then
   alias hub-create="(pvim | hub issue create -F -)"

--- a/bash/.bashrc.d/10-python
+++ b/bash/.bashrc.d/10-python
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 # python specifics
 if [ -d "${HOME}/.pyenv" ] || [ -L "${HOME}/.pyenv" ]; then
   export PYENV_ROOT="$HOME/.pyenv"

--- a/bash/.bashrc.d/10-ruby
+++ b/bash/.bashrc.d/10-ruby
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 # ruby specifics
 if command -v rbenv > /dev/null 2>&1; then
   eval "$(rbenv init -)"

--- a/bash/.bashrc.d/11-cloud
+++ b/bash/.bashrc.d/11-cloud
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 # cloud aliases
 
 # Mapping AWS code to region (.i.e. N. Virginia => us-east-1)
@@ -12,3 +12,27 @@ aws-region() {
     echo "$regions" | jq -r '.[] | [ .code, .name ] | @tsv'
   fi
 }
+
+if command -v aws > /dev/null 2>&1; then
+  # Generate a temporary set of AWS credentials
+  # Useful when tool require AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+  # Make sure to export AWS_SESSION_TOKEN as well
+  aws-temp-keys() {
+    # shellcheck disable=SC2068
+    aws sts assume-role --role-session-name temp-"$(date +%s)" $@
+  }
+
+  # Clean up the mess of AWS credentials if any are set
+  aws-env-clean() {
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_DEFAULT_REGION AWS_REGION
+  }
+
+  # Set env of AWS credentials I cant remember
+  aws-env-set() {
+    exs=(AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN)
+    for ex in "${exs[@]}";do
+      read -rp "Enter ${ex}: " resp
+      export "$ex"="$resp"
+    done
+  }
+fi

--- a/bash/.bashrc.d/11-openssl
+++ b/bash/.bashrc.d/11-openssl
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 ssl-grab(){
   local host="$1"
   if [ -z "${host}" ]; then

--- a/bash/.bashrc.d/11-osx
+++ b/bash/.bashrc.d/11-osx
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
 
 # OSX Platform specifics
 # shellcheck disable=SC2154

--- a/bash/.bashrc.d/11-vagrant
+++ b/bash/.bashrc.d/11-vagrant
@@ -1,5 +1,6 @@
 # shellcheck disable=SC2148
-# vi:syntax=sh
+# vi:filetype=sh
+
 # vagrant specifics
 if command -v vagrant > /dev/null 2>&1; then
   # Disable vagrant box warning

--- a/docs/APT.md
+++ b/docs/APT.md
@@ -1,5 +1,10 @@
 # Apt
 
+At the very least
+```
+export DEBIAN_FRONTEND=noninteractive
+```
+
 ## My desired default
 
 Make sure to configure apt to default to:
@@ -11,3 +16,11 @@ Make sure to configure apt to default to:
 This will allow `dpkg` to not prompt a user for what to do with a conflicting default config
 file from a package and instead just add a suffix `.dpkg-dist`. Similar to `.rpm`'s default
 behavior
+
+Can be addding  `/etc/apt/apt.conf.d/local`:
+
+```
+Dpkg::Options {
+   "--force-confold";
+}
+```

--- a/docs/BHYVE.md
+++ b/docs/BHYVE.md
@@ -1,0 +1,108 @@
+# Bhyve
+
+## Config
+
+Install required packages
+```
+pkg install vm-bhyve grub2-bhyve
+```
+
+Set configuration for byhve-vm
+```
+sysrc vm_enable="YES"
+sysrc vm_dir="zfs:zroot/vm"
+sysrc vm_delay="5"
+```
+
+Setup ZFS
+```
+zfs create -o mountpoint=/vm zroot/vm
+vm init
+```
+> NOTE: Assuming the pool on the system is zroot
+
+Copy over config templates:
+```
+cp /usr/local/share/examples/vm-bhyve/* /vm/.templates/
+```
+
+Since `bridge0` exists for jails, well just leverage it for vms too:
+
+```
+vm switch create -t manual -b bridge0 public
+```
+
+## Datastore
+
+You can add iso to the default datastore for later use:
+```
+vm iso <URL or path>
+```
+
+Confirm its been added:
+
+```
+ls -lah /vm/.iso/
+```
+
+## Provision vms
+
+Leverage cloud imgs if possible, since `bhyve-vm` supports cloud-init and adding public keys out of the box
+
+### Fresh
+
+Create the vm and disk:
+
+```
+vm create -t debian -s 20G deb1
+```
+
+Configure it if necessary:
+```
+vm configure deb1
+```
+> NOTE: On debian the defaults worked fine
+
+Install using iso from datastore:
+
+```
+vm install deb1 debian-10.0.0-amd64-netinst.iso
+```
+
+Then get a console up:
+
+```
+vm console deb1
+```
+> NOTE: Follow install prompts
+> Additionally I did need to install grub on /dev/sda1
+
+### Snapshot
+
+Currently theres a default snapshot for debian:
+
+```
+vm clone deb1@debianbase:v1 deb2
+```
+
+Once online youll need to force the regen of the ssh keys:
+
+```
+dpkg-reconfigure openssh-server
+sudo systemctl restart ssh
+```
+
+
+## Cloudinit
+
+Create a cloudinit vm from nothing (doesnt work with -s yet):
+
+```
+vm create -t ubuntu -i ubuntu-18.04-server-cloudimg-amd64.img -s 80G -C -k /root/robs.key robstest4
+```
+> NOTE: Make sure -k <key> has correct read permissions
+
+
+## Refs:
+
+1. Good `vm-bhyve` guide: https://www.davd.io/install-ubuntu-on-freebsd-with-bhyve/

--- a/docs/PODCASTS.md
+++ b/docs/PODCASTS.md
@@ -5,7 +5,7 @@
 Tracking past podcasts so I remember ones Ive already tried to listen to.
 
 podcast | unsubscribe date | link | reason
---- | --- | ---
+--- | --- | --- | ---
 Garbage | 07/08/19 | https://garbage.fm/ | dead
 Hacker Public Radio | 07/08/19 | http://hackerpublicradio.org/about.php | content irrelative
 Iron Sysadmin | 07/08/19 | https://www.ironsysadmin.com/ | content irrelevant

--- a/docs/PORTS.md
+++ b/docs/PORTS.md
@@ -1,0 +1,31 @@
+# Ports
+
+## Generating a patch file
+
+Start with the top section 4.4
+https://www.freebsd.org/doc/en_US.ISO8859-1/books/porters-handbook/slow-patch.html
+
+Also note that if you need to do this conditionally (based on freebsd version, etc.), then suffix patch with `extra-`
+and add the conditional block like:
+
+```
+.include <bsd.port.options.mk>
+
+# Patch in the iconv const qualifier before this
+.if ${OPSYS} == FreeBSD && ${OSVERSION} < 1100069
+EXTRA_PATCHES=  ${PATCHDIR}/extra-patch-fbsd10
+.endif
+
+.include <bsd.port.mk>
+```
+> OSVERSION can be looked up by `uname -U`
+
+
+## Generating a patch for bugzilla
+
+Assuming your ports tree was cloned down with `git`:
+
+```
+git format-patch HEAD~<num of commits to convert to patch>
+```
+> Ref: http://nickdesaulniers.github.io/blog/2017/05/16/submitting-your-first-patch-to-the-linux-kernel-and-responding-to-feedback/

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,12 @@ Because I can never remember some of these things:
 
 * [apt](./APT.md)
 * [aws](./AWS.md)
+* [bhyve](./BHYVE.md)
 * [docker](./DOCKER.md)
 * [git](./GIT.md)
 * [podcasts](./PODCASTS.md)
 * [ruby](./RUBY.md)
 * [rbenv](./RBENV.md)
+* [serial](./SERIAL.md)
 * [weechat](./WEECHAT.md)
 * [workstation-osx](./WORKSTATION-OSX.md)

--- a/docs/SERIAL.md
+++ b/docs/SERIAL.md
@@ -1,0 +1,15 @@
+# Serial
+
+## Modifying TTY
+
+```
+export TERM=xterm
+stty rows 80
+stty columns 80
+```
+> NOTE: Useful for bhyve
+
+
+## Refs
+
+1. Not being able to resize columns on `/dev/nmdm`: https://lists.freebsd.org/pipermail/freebsd-virtualization/2014-November/003183.html

--- a/vim/.vim/spell/tech.utf-8.add
+++ b/vim/.vim/spell/tech.utf-8.add
@@ -24,3 +24,4 @@ jinja
 unicode
 automount
 nfs
+toolchain

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -40,6 +40,7 @@ autocmd BufEnter *.py colorscheme icansee
 autocmd BufEnter *.rb colorscheme icansee
 autocmd BufEnter *.tf* colorscheme icansee
 autocmd BufEnter *.go colorscheme icansee
+autocmd BufEnter *.rego colorscheme icansee
 autocmd BufEnter *.yaml colorscheme vividchalk
 autocmd BufEnter *.yml colorscheme vividchalk
 
@@ -54,6 +55,12 @@ autocmd FileType make setlocal noexpandtab
 
 " Enable spellcheck for commit messages
 autocmd FileType gitcommit setlocal spell
+
+" Autoformat plugin and whitelist
+" this plugin requires python be avaible in $PATH
+let g:autoformat_autoindent = 0
+let g:autoformat_retab = 0
+let g:autoformat_verbosemode = 0
 
 " Pythonisms
 let g:autopep8_max_line_length=120
@@ -83,6 +90,12 @@ autocmd BufRead,BufNewFile *.slide set filetype=slide
 " Yaml
 let g:syntastic_yaml_checkers = ['yamllint']
 autocmd BufNewFile *.yaml,*.yml 0r ~/.vim/templates/skeleton.yaml
+
+" Rego
+let g:formatdef_rego = '"opa fmt"'
+let g:formatters_rego = ['rego']
+" Default to always autofmt rego
+autocmd BufWritePre *.rego Autoformat
 
 " Fix Vim Colors for FreeBSD
 if &term =~ "xterm" || &term =~ "screen"

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -61,10 +61,12 @@ autocmd FileType gitcommit setlocal spell
 let g:autoformat_autoindent = 0
 let g:autoformat_retab = 0
 let g:autoformat_verbosemode = 0
+" Toggle autofmt whitelist for fmt func
+let g:my_autofmt_whitelist = ['sh', 'python']
 
 " Pythonisms
-let g:autopep8_max_line_length=120
-let g:autopep8_disable_show_diff=1
+let g:formatdef_autopep8 = "'autopep8 - --max-line-length 120'"
+let g:formatters_python = ['autopep8']
 
 " Rubyisms
 autocmd BufNewFile Gemfile 0r ~/.vim/templates/ruby/Gemfile
@@ -151,15 +153,19 @@ endfunction
 
 " fmt
 " to check format use: set filetype?
+"
+" This is specifically for languages that havent historically
+" had a autofmt type of implementation
 function! <SID>fmt()
   if &ft == "json"
     "python35+ doesnt sort keys alpha by default
     "https://hg.python.org/cpython/rev/58a871227e5b
     %!if [ $(command -v python3) ];then python3 -m json.tool;else python -m json.tool;fi
     echo "fmt json"
-  elseif &ft == "python"
-    call Autopep8()
-    echo "fmt python"
+  elseif index(g:my_autofmt_whitelist, &ft) >= 0
+    echo "enabling fmt for" &ft
+    autocmd BufWritePre * Autoformat
+    execute ':w'
   elseif &ft == "cert"
     "set textwidth=64
     "call :gq


### PR DESCRIPTION
## Description

Needed some small helper functions for `awscli` and added `autoformat` for `rego` then included it for `autopep8` instead of the dedicated `autopep8` plugin

## Testing
* Validated `aws` functions work as intended
* Validated `autoformat` plugin works as expected with `rego`, `sh` and `python`