### PR TITLE
Support tmux 2.9+ and retain legacy tmux config

### DIFF
--- a/tmux-pre2.9/.tmux.conf
+++ b/tmux-pre2.9/.tmux.conf
@@ -1,0 +1,66 @@
+# Set environment variables
+run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | cut -d' ' -f2)"
+
+# Rebind C-a to be the default command sequence
+set-option -g prefix C-a
+unbind-key C-b
+
+# Nested tmux
+bind-key a send-prefix
+
+# Set escape time to 0
+set-option -sg escape-time 0
+
+# Set the default terminal to screen-256color
+set -g default-terminal "screen-256color"
+
+# Bind reload key
+bind r source-file ~/.tmux.conf \; display-message "Config reloaded..."
+
+# That #hjkllife
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+bind-key H previous-window
+bind-key L next-window
+
+# Set Window Notifications
+setw -g monitor-activity on
+set -g visual-activity on
+
+# Highlight active window
+set-window-option -g window-status-current-bg white
+
+# Set history limit
+set-option -g history-limit 10000
+
+# Tip: list-keys -t vi-copy
+# Shows all vi-copy  commands
+# List all paste buffers.
+#  -           Delete the most recently copied buffer of text.
+#  =           Choose which buffer to paste interactively from a list.
+#  [           Enter copy mode to copy text or view the history.
+#  ]           Paste the most recently copied buffer of text.
+
+# vi Mode
+set-window-option -g mode-keys vi
+# Add some vi comfort
+unbind p
+bind p paste-buffer
+# Use vi-style key bindings in copy and choice modes
+set -g mode-keys vi
+
+# Check version due to bind changes in 2.4. bc return true as 1
+# This will only work up to tmux 2.8
+if-shell '[ $(echo "$TMUX_VERSION >= 2.4" | bc -l) == 1 ]' \
+"\
+	bind-key -T copy-mode-vi v send -X begin-selection; \
+	bind-key -T copy-mode-vi y send -X copy-selection; \
+	bind-key -T copy-mode-vi V send -X rectangle-toggle; \
+" "\
+	bind -t vi-copy v begin-selection; \
+	bind -t vi-copy y copy-selection; \
+	bind -t vi-copy V rectangle-toggle; \
+"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,5 +1,4 @@
-# Set environment variables
-run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | cut -d' ' -f2)"
+# Configuration for tmux 2.9+
 
 # Rebind C-a to be the default command sequence
 set-option -g prefix C-a
@@ -31,7 +30,7 @@ setw -g monitor-activity on
 set -g visual-activity on
 
 # Highlight active window
-set-window-option -g window-status-current-bg white
+set-window-option -g window-status-current-style bg=white
 
 # Set history limit
 set-option -g history-limit 10000
@@ -49,17 +48,12 @@ set-window-option -g mode-keys vi
 # Add some vi comfort
 unbind p
 bind p paste-buffer
+
 # Use vi-style key bindings in copy and choice modes
 set -g mode-keys vi
 
-# Check version due to bind changes in 2.4. bc return true as 1
-if-shell '[ $(echo "$TMUX_VERSION >= 2.4" | bc -l) == 1 ]' \
-"\
-	bind-key -T copy-mode-vi v send -X begin-selection; \
-	bind-key -T copy-mode-vi y send -X copy-selection; \
-	bind-key -T copy-mode-vi V send -X rectangle-toggle; \
-" "\
-	bind -t vi-copy v begin-selection; \
-	bind -t vi-copy y copy-selection; \
-	bind -t vi-copy V rectangle-toggle; \
-"
+# Using "bind -T" which was introduced in 2.9 to replace bind-key
+# https://raw.githubusercontent.com/tmux/tmux/2.9/CHANGES
+bind -T copy-mode-vi "v" send-keys -X begin-selection
+bind -T copy-mode-vi "y" send-keys -X copy-selection
+bind -T copy-mode-vi "V" send-keys -X rectangle-toggle


### PR DESCRIPTION
## Description

Not ideal but need to finally support tmux 2.9+ config changes and will leave the legacy pre 2.9 config in the repo for scenarios where a older version of tmux is present.