### PR TITLE
Adding nix-sha and disable checkpoint env var

### DIFF
--- a/bash/.bashrc.d/11-hashicorp
+++ b/bash/.bashrc.d/11-hashicorp
@@ -1,0 +1,7 @@
+# shellcheck disable=SC2148
+# vi:filetype=sh
+
+# hashicorp tool specifics
+# Disable any autocheck warning
+# https://www.terraform.io/docs/commands/index.html#upgrade-and-security-bulletin-checks
+export CHECKPOINT_DISABLE=yes

--- a/bash/.bashrc.d/11-nix
+++ b/bash/.bashrc.d/11-nix
@@ -4,4 +4,8 @@
 if [ -f "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   # shellcheck disable=SC1090
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+
+nix-sha(){
+  nix-prefetch-url --unpack https://github.com/"$1"/archive/"$2".tar.gz
+}
 fi


### PR DESCRIPTION
nix-sha alias to leverage some of the sha generation when working on nixpkgs. And globally disable checkpoint env var since I dont want to have applications comment about updates when required to use older versions.