### PR TITLE
[READY] Adding git config work include and GNUreadline config

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -44,3 +44,4 @@
 
 [include]
   path = ~/.gitconfig.d/hub
+  path = ~/.gitconfig.d/99-work

--- a/gnureadline/.inputrc
+++ b/gnureadline/.inputrc
@@ -1,0 +1,2 @@
+# Sanity
+set bell-style none

--- a/make/default-pkgs.mk
+++ b/make/default-pkgs.mk
@@ -4,6 +4,7 @@ bin
 dircolors
 gcloud
 git
+gnureadline
 mariadb
 ruby
 tmux

--- a/make/workstation-pkgs.mk
+++ b/make/workstation-pkgs.mk
@@ -7,6 +7,7 @@ fonts
 gcloud
 git
 gnupg
+gnureadline
 i3
 linopen
 mariadb


### PR DESCRIPTION
See commit message for more details, but git config via normal 99 convention and GNUreadline config to stop 🔔 .

Confirmed working:

```
 $ ls -lah ~/.inputrc
lrwxrwxrwx 1 rherna rherna 29 Dec  3 12:40 /home/rherna/.inputrc -> dotfiles/gnureadline/.inputrc
```