### PR TITLE
[READY] - Disable ondemand CPU service and command not found

### DIFF
--- a/_bootstrap/robs-prep-ubuntu.sh
+++ b/_bootstrap/robs-prep-ubuntu.sh
@@ -4,3 +4,11 @@
 # Leave the rest of nix
 sudo apt-get update
 sudo apt-get install stow tmux vim git curl xsel
+
+# Turn off ondemand CPU schedule that slows the system down
+sudo systemctl stop ondemand
+sudo systemctl disable ondemand
+
+# Verify that its good
+sudo cat /sys/devices/system/cpu/cpufreq/policy*/scaling_governor
+echo "will need to reboot to clear ondemand cpu scheduling"

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -138,6 +138,10 @@ alias rehash="hash -r"
 # Allows for piping vim doc
 alias pvim="(trap 'rm ~/temp$$' exit; vim -c 'setlocal spell' ~/temp$$ >/dev/tty; cat ~/temp$$)"
 
+# Turnoff any command not found "features"
+# Ubuntu is the biggest abuser here
+type -p command_not_found_handle && unset command_not_found_handle
+
 # Save my sanity from long dirs
 if [[ -d "$HOME/symlinks" ]]; then
   export CDPATH=${HOME}/symlinks


### PR DESCRIPTION
## Description

Ubuntu makes fun "suggestions" that just get old after awhile:
```
$ ehco "hello"                                                                                                                                                             
                                                                                                                                                                                                                   
Command 'ehco' not found, did you mean:

  command 'echo' from deb coreutils (8.30-3ubuntu2)

Try: sudo apt install <deb name>
```

Also ran into a throttling problem with `ondemand` CPU scheduling 