### PR TITLE
[READY] - Autoformat vim plugin missing and housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ vim/.vim/plugged/
 
 ### awscli  ###
 aws/.aws/cli/cache/
+aws/.aws/credentials
 
 ### git ###
 git/.gitconfig.d/hub

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,4 +23,8 @@ test: test-md
 vim-plug:
 	vim -T dumb -c ":PlugInstall" -c ":q" -c ":q"
 
+# Assumes plug entries have been removed from .vimrc
+vim-plug-clean:
+	vim -T dumb -c ":PlugClean!" -c ":q" -c ":q"
+
 world: submodules stow vim-plug

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,8 @@ test: test-md
 vim-plug:
 	vim -T dumb -c ":PlugInstall" -c ":q" -c ":q"
 
+# Assumes plug entries have been removed from .vimrc
+vim-plug-clean:
+	vim -T dumb -c ":PlugClean" -c ":q" -c ":q"
+
 world: submodules stow vim-plug

--- a/bin/bin/wmi.sh
+++ b/bin/bin/wmi.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-curl --max-time 10 https://canihazip.com/s
+curl --max-time 10 https://ifconfig.me/ip

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -4,6 +4,7 @@ set nocompatible
 " Vim Plug
 call plug#begin()
 Plug 'vim-syntastic/syntastic', { 'commit': 'd31e270cc8affc6338a9ed44e2efcaec0ca4cd34' }
+Plug 'vim-autoformat/vim-autoformat', {'commit': 'd616fcf8a747f86bd3b26004b83ea5b7c7526df1' }
 Plug 'hashivim/vim-terraform', { 'commit': 'c8c9bbd70da65e2c0bcba2947c4061a7c3e24e69' }
 Plug 'fatih/vim-go', {'commit': 'f5d34f40d6757470f40600000c9c08de142d7ced' }
 Plug 'LnL7/vim-nix', {'commit': 'a3eed01f4de995a51dfdd06287e44fcb231f6adf' }


### PR DESCRIPTION
## 

Follow up from: https://github.com/sarcasticadmin/dotfiles/pull/54

- autoformat was missing after vim-plug migration
- Updating `wmi.sh` since previous url was broken
- Adding `vim-plug-clean` if/when uninstalling vim plug plugins