### PR TITLE
[READY] - Toggle autoformat and init docker-ip alias

### DIFF
--- a/bash/.bashrc.d/10-docker
+++ b/bash/.bashrc.d/10-docker
@@ -14,6 +14,11 @@ if command -v docker > /dev/null 2>&1; then
     docker inspect --format='{{index .RepoDigests 0}}' "$image"
   }
 
+  docker-ip() {
+    local id=$1
+    docker inspect --format='{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$id"
+  }
+
   # Override config.json for things like ps format
   if [ -d "${HOME}"/.docker.d ];then
     export DOCKER_CONFIG="${HOME}/.docker.d"

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -201,23 +201,26 @@ function! <SID>CheckSpelling()
   endif
 endfunction
 
-" fmt
-" to check format use: set filetype? i.e. buffer's filetype
-"
-" This is specifically for languages that havent historically
-" had a autofmt type of implementation
+" fmt so I dont have to think about it
 function! <SID>fmt()
+  " TODO: see if we can move this into autofmt
   if &ft == "json"
     "python35+ doesnt sort keys alpha by default
     "https://hg.python.org/cpython/rev/58a871227e5b
     %!if [ $(command -v python3) ];then python3 -m json.tool;else python -m json.tool;fi
     echo "fmt json"
-  " Only fmt on whitelisted languages that way
-  " I dont get any crazy surprises about defaults
+  " Check to see if autofmt is already loaded
+  elseif exists("g:autofmt_loaded")
+    "only works since I dont have anything else manipulating BufWrite
+    autocmd! BufWrite *
+    echo "nofmt" &ft
+    unlet g:autofmt_loaded
+  " Only fmt on whitelisted languages that way I dont get any crazy surprises about formatting defaults on save
   "
-  " Havent found a good way to detect calling Autoformat
-  " to be able to toggle it on and off
+  " Havent found a good way to detect calling Autoformat to be able to toggle it on and off. For now well let and unlet a
+  " var to be the toggle
   elseif index(g:my_autofmt_whitelist, &ft) >= 0
+    let g:autofmt_loaded = 1
     autocmd BufWrite * Autoformat
     echo "fmt" &ft
   elseif &ft == "cert"


### PR DESCRIPTION
# Description

- Cant ever remember how to get a container's ip with docker: `docker-ip`
- Finally able to toggle autoformat, although I wish it could be better since Im manipulating the entire write buffer