### PR TITLE
[READY] - nocolor, revert i3 prev workspace, and python pref

### DIFF
--- a/bash/.bashrc.d/11-colors
+++ b/bash/.bashrc.d/11-colors
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2148
+# vi:syntax=sh
 # get rid of colors from command line tools
 # Ref: https://unix.stackexchange.com/a/111936
-alias stripcolors='sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g"'
+alias nocolor='sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g"'

--- a/i3/.i3/config
+++ b/i3/.i3/config
@@ -140,9 +140,6 @@ client.unfocused $inactive-bg-color $inactive-bg-color $inactive-text-color
 client.focused_inactive $inactive-bg-color $inactive-bg-color $inactive-text-color
 client.urgent $urgent-bg-color $urgent-bg-color $text-color
 
-# Go back to previous workspace by hitting the original destination workspace again
-workspace_auto_back_and_forth yes
-
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)
 bar {

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -93,7 +93,7 @@ let g:ale_linters_explicit = 1
 let g:ale_linters = {
 \   'go': ['gofmt'],
 \   'nix': ['nixpkgs-fmt'],
-\   'python': ['black'],
+\   'python': ['pylint'],
 \   'rego': ['opafmt'],
 \   'sh': ['shellcheck'],
 \   'terraform': ['terraform'],
@@ -103,9 +103,12 @@ let g:ale_linters = {
 let g:ale_fixers = {
 \   '*': ['remove_trailing_lines', 'trim_whitespace'],
 \   'go': ['gofmt'],
+\   'python': ['black'],
 \   'nix': ['nixpkgs-fmt'],
 \   'terraform': ['terraform'],
 \}
+
+let g:ale_python_black_use_global = 1
 
 " Rubyisms
 autocmd BufNewFile Gemfile 0r ~/.vim/templates/ruby/Gemfile


### PR DESCRIPTION
## Description

- rename bash fun from stripcolors -> nocolor
- Revert "enable i3 workspace quick return"
- init python lint and format via ale

## Tests

- Confirmed `pylint` and `black` on development environment
- i3 quick return no longer enabled
