### PR TITLE
[READY] - gitconfig remotes and rss feed update

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -76,3 +76,7 @@
 [push]
   # default --set-upstream branch to the same name as local branch
   default = current
+
+[clone]
+  # "origin" is for forks which I do less often
+  defaultRemoteName = upstream

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -59,6 +59,9 @@
     }; f"
   tagtype = "for-each-ref refs/tags"
 
+[lfs]
+  # Ignore excessive nagging: "Locking support detected on remote "origin". Consider enabling it with:"
+  locksverify = false
 
 [filter "lfs"]
   clean    = git-lfs clean -- %f

--- a/newsboat-osx/.newsboat/config
+++ b/newsboat-osx/.newsboat/config
@@ -9,6 +9,7 @@ highlight-article "feedtitle =~ \"Webshit Weekly\"" green default bold
 highlight-article "tags =~ \"security\"" red default bold
 highlight-article "tags =~ \"dtrace\"" green default bold
 highlight-article "tags =~ \"reproducibility\"" green default bold
+highlight-article "tags =~ \"individual\"" yellow default bold
 
 # Flipflop browser open
 unbind-key o

--- a/newsboat-osx/.newsboat/urls
+++ b/newsboat-osx/.newsboat/urls
@@ -26,7 +26,6 @@ https://www.schneier.com/feed/atom tech security "~Schneier" "!hidden"
 
 # Comics
 http://xkcd.com/rss.xml comics "!xkcd"
-http://feed.dilbert.com/dilbert/daily_strip comics "~Dilbert" "!hidden"
 http://www.phdcomics.com/gradfeed.php comics "!PHD"
 http://feeds.feedburner.com/GeekAndPoke comics "!Geek&Poke"
 https://www.commitstrip.com/en/feed/ comics "!CommitStrip"

--- a/newsboat-osx/.newsboat/urls
+++ b/newsboat-osx/.newsboat/urls
@@ -57,6 +57,7 @@ https://winlink.org/blog/feed ham winlink "~Winlink Sysops" "!hidden"
 https://www.reddit.com/r/amateurradio+hamfest+hamradio+hsmm_mesh+hamitforward+antennasporn/new/.rss?sort=new ham "~Reddit HAM" "!hidden"
 https://groups.io/g/diy599/rss ham qrp "~DIY599" "!hidden"
 https://groups.io/g/APRS/rss ham aprs "~APRS" "!hidden"
+https://www.kb6nu.com/feed/ ham individual "~Dan KB6NU" "!hideen"
 
 # Query Aggregators
 "query:Tech News:tags # \"tech\""

--- a/newsboat-osx/.newsboat/urls
+++ b/newsboat-osx/.newsboat/urls
@@ -34,6 +34,7 @@ https://turnoff.us/feed.xml comics "!Turnoff"
 https://patchfriday.com/rss.xml comics "!PatchFriday"
 https://thejenkinscomic.wordpress.com/feed/ comics "!The Jenkins"
 https://www.webtoons.com/en/challenge/madebytio/rss?title_no=597759 comics "~MadeByTio" "!hidden"
+https://workchronicles.com/feed comics "~Work Chronicles" "!hidden"
 
 # News
 http://feeds.bbci.co.uk/news/world/rss.xml news "!BBC"

--- a/newsboat/.newsboat/config
+++ b/newsboat/.newsboat/config
@@ -9,6 +9,7 @@ highlight-article "feedtitle =~ \"Webshit Weekly\"" green default bold
 highlight-article "tags =~ \"security\"" red default bold
 highlight-article "tags =~ \"dtrace\"" green default bold
 highlight-article "tags =~ \"reproducibility\"" green default bold
+highlight-article "tags =~ \"individual\"" yellow default bold
 
 # Flipflop browser open
 unbind-key o

--- a/newsboat/.newsboat/urls
+++ b/newsboat/.newsboat/urls
@@ -26,7 +26,6 @@ https://www.schneier.com/feed/atom tech security "~Schneier" "!hidden"
 
 # Comics
 http://xkcd.com/rss.xml comics "!xkcd"
-http://feed.dilbert.com/dilbert/daily_strip comics "~Dilbert" "!hidden"
 http://www.phdcomics.com/gradfeed.php comics "!PHD"
 http://feeds.feedburner.com/GeekAndPoke comics "!Geek&Poke"
 https://www.commitstrip.com/en/feed/ comics "!CommitStrip"

--- a/newsboat/.newsboat/urls
+++ b/newsboat/.newsboat/urls
@@ -57,6 +57,7 @@ https://winlink.org/blog/feed ham winlink "~Winlink Sysops" "!hidden"
 https://www.reddit.com/r/amateurradio+hamfest+hamradio+hsmm_mesh+hamitforward+antennasporn/new/.rss?sort=new ham "~Reddit HAM" "!hidden"
 https://groups.io/g/diy599/rss ham qrp "~DIY599" "!hidden"
 https://groups.io/g/APRS/rss ham aprs "~APRS" "!hidden"
+https://www.kb6nu.com/feed/ ham individual "~Dan KB6NU" "!hideen"
 
 # Query Aggregators
 "query:Tech News:tags # \"tech\""

--- a/newsboat/.newsboat/urls
+++ b/newsboat/.newsboat/urls
@@ -34,6 +34,7 @@ https://turnoff.us/feed.xml comics "!Turnoff"
 https://patchfriday.com/rss.xml comics "!PatchFriday"
 https://thejenkinscomic.wordpress.com/feed/ comics "!The Jenkins"
 https://www.webtoons.com/en/challenge/madebytio/rss?title_no=597759 comics "~MadeByTio" "!hidden"
+https://workchronicles.com/feed comics "~Work Chronicles" "!hidden"
 
 # News
 http://feeds.bbci.co.uk/news/world/rss.xml news "!BBC"


### PR DESCRIPTION
## Description

- disable git-lfs lock verification
- set default remote during git clone to upstream
- dilbert rss feed is no more
- init work chronicles comic feed
- init KB6NU ham feed
- highlight individuals rss feed in yellow
