### PR TITLE
[READY] - MANPAGER update and i3 autostart alacritty

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -128,7 +128,7 @@ export PAGER="less +Gg -R"
 
 # Leave manpage place on screen after exit and set preference to read entire
 # file and start back at the beginning to get percentage info
-export MANPAGER="/usr/bin/env less -X +Gg"
+export MANPAGER="less -X +Gg"
 
 # Color for manpages
 export LESS_TERMCAP_mb=$'\e[1;31m'           # begin bold

--- a/i3/.i3/config
+++ b/i3/.i3/config
@@ -170,7 +170,7 @@ bar {
 }
 
 #exec --no-startup-id feh --bg-fill ~/.backgrounds/pluto_desktop.jpg
-exec --no-startup-id i3-msg 'workspace $ws1; exec i3-sensible-terminal -e tmux'
+exec --no-startup-id i3-msg 'workspace $ws1; exec 'alacritty | i3-sensible-terminal' -e tmux'
 exec --no-startup-id i3-msg 'workspace $ws2; exec firefox; workspace $ws1'
 
 bindsym Control+mod1+l exec sh ~/.i3/i3lock.sh

--- a/newsboat-osx/.newsboat/urls
+++ b/newsboat-osx/.newsboat/urls
@@ -50,7 +50,7 @@ https://status.aws.amazon.com/rss/all.rss status "~AWS Status" "!hidden"
 https://azurestatuscdn.azureedge.net/en-us/status/feed/ status "~Azure Status" "!hidden"
 https://status.cloud.google.com/en/feed.atom status "~GCP Status" "!hidden"
 https://www.githubstatus.com/history.rss status "~GitHub Status" "!hidden"
-https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss "~GitLab Status" "!hidden"
+https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss status "~GitLab Status" "!hidden"
 https://status.slack.com/feed/rss status "~Slack Status" "!hidden"
 
 # HAM

--- a/newsboat/.newsboat/urls
+++ b/newsboat/.newsboat/urls
@@ -50,7 +50,7 @@ https://status.aws.amazon.com/rss/all.rss status "~AWS Status" "!hidden"
 https://azurestatuscdn.azureedge.net/en-us/status/feed/ status "~Azure Status" "!hidden"
 https://status.cloud.google.com/en/feed.atom status "~GCP Status" "!hidden"
 https://www.githubstatus.com/history.rss status "~GitHub Status" "!hidden"
-https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss "~GitLab Status" "!hidden"
+https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss status "~GitLab Status" "!hidden"
 https://status.slack.com/feed/rss status "~Slack Status" "!hidden"
 
 # HAM


### PR DESCRIPTION
## Description

- newsboat: missing status tag for gitlab
- bash: remove env path from MANPAGER
- i3: include alacritty in startup

## Tests

* Tested on `driver`
