### PR TITLE
[READY] - newboat query cache and Xmodmap load

### DIFF
--- a/i3/.i3/config
+++ b/i3/.i3/config
@@ -171,6 +171,9 @@ bar {
 }
 
 #exec --no-startup-id feh --bg-fill ~/.backgrounds/pluto_desktop.jpg
+# print the current keymap table: xmodmap -pke
+# load changes adhoc:  xmodmap ~/.Xmodmap
+exec --no-startup-id '[[ -f ~/.Xmodmap ]] && xmodmap ~/.Xmodmap'
 exec --no-startup-id i3-msg 'workspace $ws1; exec 'alacritty | i3-sensible-terminal' -e tmux'
 exec --no-startup-id i3-msg 'workspace $ws2; exec firefox; workspace $ws1'
 

--- a/i3/.xinitrc
+++ b/i3/.xinitrc
@@ -1,1 +1,2 @@
+# vi:syntax=sh
 /usr/local/bin/i3

--- a/newsboat-osx/.newsboat/config
+++ b/newsboat-osx/.newsboat/config
@@ -35,6 +35,10 @@ suppress-first-reload yes
 auto-reload yes
 reload-time 30
 reload-threads 4
+# The most import setting of them all since I use query feeds exclusively makes sure to use the prepopulate cached feeds
+# on startup
+# ref: https://github.com/newsboat/newsboat/issues/1408
+prepopulate-query-feeds yes
 
 # Clean up
 keep-articles-days 14

--- a/newsboat-osx/.newsboat/urls
+++ b/newsboat-osx/.newsboat/urls
@@ -36,6 +36,7 @@ https://www.freebsd.org/events/feed.xml tech freebsd events "~FreeBSD Events" "!
 # src: https://meta.discourse.org/t/discourse-rss-feeds-list/264134
 https://discourse.nixos.org/c/events/13.rss tech nix "~Nix Disco Events" "!hidden"
 https://discourse.nixos.org/c/announcements/8.rss tech nix "~Nix Disco Announce" "!hidden"
+https://nixpkgs.news/rss.xml tech nix "~Nixpkgs News" "!hidden"
 
 # Comics
 http://xkcd.com/rss.xml comics "!xkcd"

--- a/newsboat/.newsboat/config
+++ b/newsboat/.newsboat/config
@@ -35,6 +35,10 @@ suppress-first-reload yes
 auto-reload yes
 reload-time 30
 reload-threads 4
+# The most import setting of them all since I use query feeds exclusively makes sure to use the prepopulate cached feeds
+# on startup
+# ref: https://github.com/newsboat/newsboat/issues/1408
+prepopulate-query-feeds yes
 
 # Clean up
 keep-articles-days 14

--- a/newsboat/.newsboat/urls
+++ b/newsboat/.newsboat/urls
@@ -36,6 +36,7 @@ https://www.freebsd.org/events/feed.xml tech freebsd events "~FreeBSD Events" "!
 # src: https://meta.discourse.org/t/discourse-rss-feeds-list/264134
 https://discourse.nixos.org/c/events/13.rss tech nix "~Nix Disco Events" "!hidden"
 https://discourse.nixos.org/c/announcements/8.rss tech nix "~Nix Disco Announce" "!hidden"
+https://nixpkgs.news/rss.xml tech nix "~Nixpkgs News" "!hidden"
 
 # Comics
 http://xkcd.com/rss.xml comics "!xkcd"


### PR DESCRIPTION
## Description

Xmodmap wasnt loading so I wasnt able to effectively use my `insert key = ""` mapping. I finally figured out how to get newboat to load its cache for query aggregated lists.

## Tests

- `driver` working as expected
