### PR TITLE
[READY] - git pat and cloudflare feed

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -47,8 +47,9 @@
 [alias]
   # commit and fixup
   can     = commit --amend --no-edit
-  # Allow for copy/paste diffs without prefixes
-  pat     = "!f() { git diff --no-prefix $@ ;}; f"
+  # Allow for copy/paste diffs without prefixes and
+  # exclude external diff: https://stackoverflow.com/a/19936510
+  pat     = "!f() { git diff --no-ext-diff $@ ;}; f"
   stats   = shortlog -sn --all --no-merges
   recap   = log master --oneline --no-merges --author=rob@sarcasticadmin.com
   recent  = for-each-ref --count=10 --sort=-committerdate refs/heads/ --format="%(refname:short)"

--- a/newsboat/.newsboat/urls
+++ b/newsboat/.newsboat/urls
@@ -67,6 +67,7 @@ https://status.cloud.google.com/en/feed.atom status "~GCP Status" "!hidden"
 https://www.githubstatus.com/history.rss status "~GitHub Status" "!hidden"
 https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss status "~GitLab Status" "!hidden"
 https://status.slack.com/feed/rss status "~Slack Status" "!hidden"
+https://www.cloudflarestatus.com/history.atom status "~Cloudflare Status" "!hidden"
 
 # HAM
 https://www.zeroretries.org/feed ham "~Zero Retries" "!hidden"


### PR DESCRIPTION
## Description

Finally fixed the `git pat` subcommand for generating patches for things like nixpkgs.

CF seems to be something I'm using more these days, so adding theres status rss feed.

## Tests
- working on `driver`
