### PR TITLE
[READY] vim: refer to correct plug dir

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -12,7 +12,7 @@ else
   " without defining this explcitly it will search undesirable paths like:
   " XDG_DATA_DIRS=/run/current-system/sw/share
   " This then can cause vim plug to fail to load plugins
-  call plug#begin($HOME.'/.vim')
+  call plug#begin($HOME.'/.vim/plugged')
 endif
 
 " One plugin encompassing linting and fmting


### PR DESCRIPTION
## Description

Looks like I broke `vimplug` when I merged https://github.com/sarcasticadmin/dotfiles/pull/107 This should fix it

## Tests
- Tested on the mac