### PR TITLE
[READY] - git: add blame rev ignore

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -106,3 +106,5 @@
 [clone]
   # "origin" is for forks which I do less often
   defaultRemoteName = upstream
+[blame]
+	ignoreRevsFile = .git-blame-ignore-revs


### PR DESCRIPTION
## Description

Take advantage of the blame ignore file and its default path in git repos if one exists

## Tests

- Verified on the scale-network repo
