### PR TITLE
[READY] - git: add blame rev ignore

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -106,5 +106,3 @@
 [clone]
   # "origin" is for forks which I do less often
   defaultRemoteName = upstream
-[blame]
-	ignoreRevsFile = .git-blame-ignore-revs


### PR DESCRIPTION
## Description

This reverts commit a093cbc3dc89e60b4458e7036a6e6f557c7f71cb.

Setting this globally causes `git blame` to fail when
.git-blame-ignore-revs is missing in a repo.

Discussion about making this blame option igore a missing
.git-blame-ignore-revs:
https://public-inbox.org/git/xmqq5ywehb69.fsf@gitster.g/T/
