### PR TITLE
[READY] - vim tf lint disable and liminix rss feed

### DIFF
--- a/newsboat/.newsboat/urls
+++ b/newsboat/.newsboat/urls
@@ -40,6 +40,7 @@ https://www.sovereigntechfund.de/feed.rss tech oss "~Sovereign Tech Fund" "!hidd
 https://discourse.nixos.org/c/events/13.rss tech nix "~Nix Disco Events" "!hidden"
 https://discourse.nixos.org/c/announcements/8.rss tech nix "~Nix Disco Announce" "!hidden"
 https://nixpkgs.news/rss.xml tech nix "~Nixpkgs News" "!hidden"
+https://www.liminix.org/feed.xml tech nix wireless "~Liminix News" "!hidden"
 
 # Comics
 http://xkcd.com/rss.xml comics "!xkcd"

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -129,16 +129,18 @@ let g:ale_lint_on_insert_leave = 0
 let g:ale_linters_explicit = 1
 " Show available linters and filetype via :ALEInfo
 " Other options via :help ale-options
+" Exclude terraform from ale_linters since 'tf validate' requires 'tf init'
+" and terraform is pretty dumb about locating a provider
+" ref: https://github.com/dense-analysis/ale/blob/a7ef1817b7aa06d0f80952ad530be87ad3c8f6e2/ale_linters/terraform/terraform.vim#L12
 let g:ale_linters = {
 \   'go': ['gofmt'],
 \   'nix': ['nixpkgs-fmt'],
 \   'python': ['flake8'],
 \   'rego': ['opafmt'],
 \   'sh': ['shellcheck'],
-\   'terraform': ['terraform'],
 \}
 
-
+" fmters
 let g:ale_fixers = {
 \   '*': ['remove_trailing_lines', 'trim_whitespace'],
 \   'go': ['gofmt'],


### PR DESCRIPTION
## Description

Keep a closer eye on liminix since it might be a viable option for scale openwrt

Remove lint of tf since it leads to annoying errors regarding tf init and provider discovery

## Tests

- Tested on macos
