### PR TITLE
newsboat: ESC is q too

### DIFF
--- a/newsboat/.newsboat/config
+++ b/newsboat/.newsboat/config
@@ -12,6 +12,9 @@ highlight-article "tags =~ \"dtrace\"" green default bold
 highlight-article "tags =~ \"reproducibility\"" green default bold
 highlight-article "tags =~ \"individual\"" yellow default bold
 
+# map ESC to q
+bind-key ESC quit
+
 # Flipflop browser open
 unbind-key o
 unbind-key O


### PR DESCRIPTION
## Description

Tired of always hitting ESC then q to leave newsboat article

## Test

- Verified working on macOS
