### PR TITLE
misc: updating git checkout-date and init psql

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -82,7 +82,7 @@
   # Quickly create a branch thats unique. Add a suffix to make it standout if needed
   # Date is prefixed for easy sorting with git branch
   checkout-date = "!f() { \
-      bn=$(printf -- 'rh/%s%s' $(date +%s) $1); \
+      bn=$(printf -- 'rh/%s%s' $(date -u +\"%y%m%d%H%M%S\") $1); \
       git checkout -b ${bn}; \
     }; f"
   fixup = "!f() { \

--- a/psql/.psqlrc
+++ b/psql/.psqlrc
@@ -1,0 +1,1 @@
+\pset pager off 


### PR DESCRIPTION
## Description

`psql` should not have the pager on by default
`git checkout-date` taking come inspiration from kyle

## Tests

- working on the mac