### PR TITLE
newsboat.urls: init anthropic red

### DIFF
--- a/newsboat/.newsboat/urls
+++ b/newsboat/.newsboat/urls
@@ -37,6 +37,8 @@ https://www.sovereigntechfund.de/feed.rss tech oss "~Sovereign Tech Fund" "!hidd
 https://www.404media.co/rss tech security law "~404 Media" "!hidden"
 https://chaos.social/@birkenhack.rss tech hacking "~Birkenhack" "!hidden"
 https://redmonk.com/latest-research/feed tech research "~Redmonk" "!hidden"
+# https://github.com/Olshansk/rss-feeds
+https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_anthropic_red.xml tech ai security "~Anthropic Red" "!hidden"
 
 # Getting discourse rss feeds
 # src: https://meta.discourse.org/t/discourse-rss-feeds-list/264134


### PR DESCRIPTION
## Description

Leverage Olshansk/rss-feeds for rss feed when page doesnt provide one

## Tests

- works on newsboat on `driver`
