### PR TITLE
newsboat: ensure cleanup of stale url refs on quit

### DIFF
--- a/newsboat/.newsboat/config
+++ b/newsboat/.newsboat/config
@@ -51,6 +51,8 @@ ignore-article "*" "age < 0"
 
 # Clean up
 keep-articles-days 14
+# if feeds/urls change its ok to cleanup stale refs
+cleanup-on-quit yes
 
 # Launch browser
 # default to browser set via BROWSER if not set


### PR DESCRIPTION
## Description

when urls are removed from an already cached newsboat db it will complain about needing to cleanup the db and pause during newsboat quit. This allows it to do the cleanup of the stale urls in the newsboat db automatically.

## Tests

- verified working on latest newsboat config and urls